### PR TITLE
feat: resume link update

### DIFF
--- a/content/sections/section4.md
+++ b/content/sections/section4.md
@@ -11,7 +11,7 @@ Feel free to message me through any of the means listed below! I'm always lookin
     {{< linkedin user="nicholas-vancise-65381619b" >}}
     {{< email email="nvancisedev@gmail.com" >}}
     {{< github user="thenick775" >}}
-    {{< resume resume="https://rawcdn.githack.com/thenick775/resume_latex/56e2ba2f5c1977f08f2f2ca254c8a544bd8834f3/resume.pdf" >}}
+    {{< resume resume="https://thenick775.github.io/resume_latex/resume.pdf" >}}
 {{< /socialhandles >}}
 
 {{< popupoverlay >}}


### PR DESCRIPTION
- raw.githack.com is down right now
- feels like it will be simpler and more reliable to serve this via GitHub pages, and then use that link here